### PR TITLE
Fixed error message for resp.status and resp.statusText in src/Server/Import.tsx.

### DIFF
--- a/src/Server/Import.tsx
+++ b/src/Server/Import.tsx
@@ -30,7 +30,7 @@ export function importGEDCOM(files: File[], csrfToken: string): Promise<ImportRe
          window.console.log('Upload failed', resp);
          return {
             success: false,
-            error: 'Upload failed with error {resp.status}, {resp.statusText}',
+            error: `Upload failed with error ${resp.status}, ${resp.statusText}`,
          };
       }
       const result: Promise<ImportResponse> = resp.json();


### PR DESCRIPTION
resp.status and resp.statusText weren't being rendered in error message. Replaced ' with ` for error message and changed {...} to ${...} for both elements.